### PR TITLE
Fixed IsPartyPublic erroring on LAN

### DIFF
--- a/LethalRichPresence/Core/Variables.cs
+++ b/LethalRichPresence/Core/Variables.cs
@@ -45,7 +45,7 @@ public class Variables
 
   public static bool IsPartyPublic()
   {
-    return GameNetworkManager.Instance.lobbyHostSettings?.isLobbyPublic;
+    return GameNetworkManager.Instance.lobbyHostSettings?.isLobbyPublic != null ? GameNetworkManager.Instance.lobbyHostSettings.isLobbyPublic : false;
   }
 
   public static string IsHostingOrMember()

--- a/LethalRichPresence/Core/Variables.cs
+++ b/LethalRichPresence/Core/Variables.cs
@@ -45,7 +45,7 @@ public class Variables
 
   public static bool IsPartyPublic()
   {
-    return GameNetworkManager.Instance.lobbyHostSettings.isLobbyPublic;
+    return GameNetworkManager.Instance.lobbyHostSettings?.isLobbyPublic;
   }
 
   public static string IsHostingOrMember()


### PR DESCRIPTION
- Fixed NullReferenceException on LAN from `IsPartyPublic` function.

![1703950865](https://github.com/AndreyMrovol/LethalRichPresence/assets/23743032/a329ec63-5fae-4018-ad72-75ff860a52fa)
