### PR TITLE
Corrected LobbyCompatibility CompatibilityLevel

### DIFF
--- a/LethalRichPresence/LobbyCompatibility.cs
+++ b/LethalRichPresence/LobbyCompatibility.cs
@@ -24,7 +24,7 @@ namespace LethalRichPresence
             LobbyCompatibility.Features.PluginHelper.RegisterPlugin(
                 "LethalRichPresence",
                 pluginVersion,
-                LobbyCompatibility.Enums.CompatibilityLevel.ClientOptional,
+                LobbyCompatibility.Enums.CompatibilityLevel.ClientOnly,
                 LobbyCompatibility.Enums.VersionStrictness.None
             );
         }


### PR DESCRIPTION
The CompatibilityLevel is currently "ClientOptional" when it should be "ClientOnly"

> **ClientOnly**
> - Mod only impacts the client.
> - Mod is not checked at all (i.e. you can join vanilla lobbies), VersionStrictness does not apply.

> **ClientOptional**
> - Not every client needs to have the mod installed, but if it is installed, the server also needs to have it. Generally used for mods that add extra (optional) functionality to the client if the server has it installed.
> - Mod must be loaded on server. Version checking depends on the VersionStrictness.